### PR TITLE
Ruby update to 2.6.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
+ruby "2.6.5"
 
 gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,5 +244,8 @@ PLATFORMS
 DEPENDENCIES
   github-pages
 
+RUBY VERSION
+   ruby 2.6.5p114
+
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
Ruby hasn't been updated for a while here
&
I was suffering from `Library not loaded: /usr/local/opt/openssl/lib/libssl.1.0.0.dylib` - and the main `biggerpockets` app had a dependency on `libssl.1.1.1.dylib` so seems like a good opportunity to fix this for smooth local-instance-running.

It looks like Heroku is fine with just having the Ruby version stated in the `Gemfile` but let me know if I have forgotten something.